### PR TITLE
Enables the django debug sidebar package

### DIFF
--- a/bookish/settings.py
+++ b/bookish/settings.py
@@ -39,7 +39,8 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'bookish',
     'fts',
-    'raven.contrib.django.raven_compat'
+    'raven.contrib.django.raven_compat',
+    'debug_toolbar'
 )
 
 MIDDLEWARE_CLASSES = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gunicorn==19.3.0
 psycopg2==2.6
 static3==0.5.1
 raven==5.2.0
+django-debug-toolbar==1.3.0


### PR DESCRIPTION
As agreed, places this in requirements.txt which means it will be on the demo site for now.

We have other debug options that will need to be removed in production as well.
